### PR TITLE
do not parse "-" or "--" as options, fixes #1

### DIFF
--- a/mainargs/src/TokenGrouping.scala
+++ b/mainargs/src/TokenGrouping.scala
@@ -31,7 +31,7 @@ object TokenGrouping{
                      current: Map[ArgSig.Named[_, B], Vector[String]]): Result[TokenGrouping[B]] = {
       remaining match{
         case head :: rest  =>
-          if (head.startsWith("-")){
+          if (head.startsWith("-") && head.exists(_ != '-')){
             keywordArgMap.get(head) match {
               case Some(cliArg: ArgSig.Flag[_]) =>
                 rec(rest, Util.appendMap(current, cliArg, ""))

--- a/mainargs/test/src/CoreTests.scala
+++ b/mainargs/test/src/CoreTests.scala
@@ -90,6 +90,12 @@ class CoreTests(allowPositional: Boolean) extends TestSuite{
       test - check(
         List("qux", "-i", "3", "-s", "x"), Result.Success("xxx")
       )
+      test - check(
+        List("qux", "-i", "3", "-s", "-"), Result.Success("---")
+      )
+      test - check(
+        List("qux", "-i", "3", "-s", "--"), Result.Success("------")
+      )
     }
 
     test("failures"){
@@ -186,6 +192,9 @@ object CorePositionalEnabledOnlyTests extends TestSuite{
       test - check(List("bar", "2"), Result.Success(2))
       test - check(List("qux", "2"), Result.Success("lolslols"))
       test - check(List("qux", "3", "x"), Result.Success("xxx"))
+      test - check(List("qux", "2", "-"), Result.Success("--"))
+      test - check(List("qux", "2", "--"), Result.Success("----"))
+      test - check(List("qux", "1", "---"), Result.Success("---"))
       test - check(
         List("qux", "-i", "3", "x"), Result.Success("xxx")
       )


### PR DESCRIPTION
This patch adds an extra check to avoid parsing things like `-` or `--` (just dashes, no name after it) as an option name, so that they can be used in positional parameters such as `copy /some/file -` 

