### PR TITLE
Fix error message for missing parameter list

### DIFF
--- a/mainargs/src-3/Macros.scala
+++ b/mainargs/src-3/Macros.scala
@@ -93,7 +93,9 @@ object Macros {
                                        annotatedParamsLists: List[List[quotes.reflect.Symbol]]): Expr[MainData[T, B]] = {
 
     import quotes.reflect.*
-    val params = method.paramSymss.headOption.getOrElse(report.throwError("Multiple parameter lists not supported"))
+    val params = method.paramSymss.headOption.getOrElse(
+      report.throwError("At least one parameter list must be declared.")
+    )
     val defaultParams = if (params.exists(_.flags.is(Flags.HasDefault))) getDefaultParams(method) else Map.empty
     val argSigsExprs = params.zip(annotatedParamsLists.flatten).map { paramAndAnnotParam =>
       val param = paramAndAnnotParam._1

--- a/mainargs/test/src/MacroErrors.scala
+++ b/mainargs/test/src/MacroErrors.scala
@@ -1,0 +1,31 @@
+package mainarg
+
+import utest._
+import mainargs.{main, arg, ParserForMethods, Flag}
+object MacroErrors extends TestSuite {
+  object MultipleParameterLists {
+    @main
+    def method_name(foo: String)(bar: String) = ()
+  }
+  object NoParameterList {
+    @main
+    def method_name = ()
+  }
+
+  def tests = Tests {
+    test("reportMultipleParametersAsError") {
+      compileError("ParserForMethods(MultipleParameterLists)").check(
+        "",
+        "Multiple parameter lists are not supported"
+      )
+    }
+
+    test("reportNoParameterAsError") {
+      compileError("ParserForMethods(NoParameterList)").check(
+        "",
+        "At least one parameter list must be declared"
+      )
+    }
+
+  }
+}


### PR DESCRIPTION
Hi, thank you for providing this nice library.
While playing around I was wonce fooled by the missleading error
message that the `@main` method had mutliple parameter lists where it actually
had none. This change should fix the error message.